### PR TITLE
Disable SVG titles when tooltips are active

### DIFF
--- a/src/d3.flameGraph.js
+++ b/src/d3.flameGraph.js
@@ -215,7 +215,8 @@
         node.append("svg:rect")
           .attr("width", function(d) { return d.dx * kx; });
 
-        node.append("svg:title");
+        if (!tooltip)
+          node.append("svg:title");
 
         node.append("foreignObject")
           .append("xhtml:div");
@@ -230,8 +231,9 @@
           .attr("fill", function(d) {return d.highlight ? "#E600E6" : colorHash(d.name); })
           .style("visibility", function(d) {return d.dummy ? "hidden" : "visible";});
 
-        g.select("title")
-          .text(label);
+        if (!tooltip)
+          g.select("title")
+            .text(label);
 
         g.select("foreignObject")
           .attr("width", function(d) { return d.dx * kx; })


### PR DESCRIPTION
When tooltips are active, the browser displays a native hover based on the title attribute at the same time the d3 tooltip is displayed, leading to two tooltips at once. Suppress DOM title tags when tooltips are in use.
